### PR TITLE
Update flask-endpoint.instructions.md

### DIFF
--- a/.github/instructions/flask-endpoint.instructions.md
+++ b/.github/instructions/flask-endpoint.instructions.md
@@ -13,9 +13,9 @@
 
 - The Python virtual environment is located in the root of the project in a **venv** folder
 - Register all blueprints in `server/app.py`
-- Use the [test instructions](./python-tests.instructions.md) when creating tests
+- Use the [test instructions](.github/instructions/python-tests.instructions.md) when creating tests
 
 ## Prototype files
 
-- [Endpoint prototype](../../server/routes/games.py)
-- [Tests prototype](../../server/tests/test_games.py)
+- [Endpoint prototype](server/routes/games.py)
+- [Tests prototype](server/tests/test_games.py)


### PR DESCRIPTION
This pull request updates the `.github/instructions/flask-endpoint.instructions.md` file to fix broken links and improve clarity.

Documentation updates:

* Fixed the link to the test instructions, correcting the path to `.github/instructions/python-tests.instructions.md`.
* Updated the paths for the "Endpoint prototype" and "Tests prototype" to relative paths starting from the root directory for consistency and accuracy.