### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,0 @@
-# For more information, see [docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax)
-
-# This repository is maintained by: 
-* @geektrainer @chrisreddington


### PR DESCRIPTION
Due to this repository's use as a template, any members of CODEOWNERS are notified whenever a PR is created to a new instance based on the template. Removing this file will make this template more maintainable.