### PR TITLE
chore: repoint Pages slug to copilot-workshops after repo rename

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Copilot Workshops — Workshop Authoring Guide
 
-This repo hosts the **workshop content** for **Copilot Workshops**, published as an Astro + Starlight site at <https://github-samples.github.io/agents-in-sdlc/>. The demo application learners build during the workshop lives in a separate repository: <https://github.com/github-samples/tailspin-toys>.
+This repo hosts the **workshop content** for **Copilot Workshops**, published as an Astro + Starlight site at <https://github-samples.github.io/copilot-workshops/>. The demo application learners build during the workshop lives in a separate repository: <https://github.com/github-samples/tailspin-toys>.
 
 **This is a content-only repo.** Do not add the demo app's application code (Astro SSR endpoints, the Drizzle data layer, UI components, Tailwind styles, or tests) here. Application changes belong in `tailspin-toys`.
 

--- a/.github/instructions/astro.instructions.md
+++ b/.github/instructions/astro.instructions.md
@@ -9,8 +9,8 @@ applyTo: 'website/**/*.{astro,mjs,ts,js}'
 
 ## Site config
 
-- Base path: `/agents-in-sdlc` (the repo's GitHub Pages slug).
-- Site URL: `https://github-samples.github.io/agents-in-sdlc/`.
+- Base path: `/copilot-workshops` (the repo's GitHub Pages slug).
+- Site URL: `https://github-samples.github.io/copilot-workshops/`.
 - **Sidebar: manually maintained** in `astro.config.mjs`. The `sidebar` array drives both the order learners see and which pages appear in navigation. New lessons must be added explicitly.
 - **Content collection** is sourced from the repo-root `docs/` directory via the custom `glob()` loader in `src/content.config.ts` (`base: '../docs'`). That loader excludes underscore-prefixed files and directories so support assets such as `_images/` don't get routed as pages. Folder landing pages are `README.md` files (so they render on github.com) rather than Starlight's default `index.md`; each carries a `slug:` in its frontmatter to reproduce the route it would otherwise get from an index file — `docs/README.md` → `slug: index` (site home `/`), `docs/<harness>/README.md` → `slug: <harness>`, and localized landings use the locale-prefixed slug (`docs/<locale>/README.md` → `slug: <locale>`, `docs/<locale>/<harness>/README.md` → `slug: <locale>/<harness>`).
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 
 - [ ] `cd website && rm -rf dist && npm run build` succeeds (target: 36 routes × 6 locales + 1 redirect = 217 built pages excluding 404; build reports 218 HTML files including 404, or note any intentional change)
 - [ ] Lychee link check passes:
-      `mkdir -p /tmp/lychee-root && ln -sfn $PWD/website/dist /tmp/lychee-root/agents-in-sdlc && lychee --offline --no-progress --root-dir /tmp/lychee-root 'website/dist/**/*.html'`
+      `mkdir -p /tmp/lychee-root && ln -sfn $PWD/website/dist /tmp/lychee-root/copilot-workshops && lychee --offline --no-progress --root-dir /tmp/lychee-root 'website/dist/**/*.html'`
 - [ ] External GitHub URLs that I changed have been clicked manually (lychee runs offline)
 
 ## Screenshots

--- a/.github/skills/build-and-verify-docs/SKILL.md
+++ b/.github/skills/build-and-verify-docs/SKILL.md
@@ -29,7 +29,7 @@ The Astro dev server is the primary preview surface (hot reload):
 cd website && npm install && npm run dev
 ```
 
-Open <http://localhost:4321/agents-in-sdlc/>. Lesson content lives in the repo-root `docs/` directory; the loader sources it via `base: '../docs'`, so no symlinks are required for preview.
+Open <http://localhost:4321/copilot-workshops/>. Lesson content lives in the repo-root `docs/` directory; the loader sources it via `base: '../docs'`, so no symlinks are required for preview.
 
 ## Verification sequence (run before every commit)
 
@@ -72,10 +72,10 @@ The Spanish title should read `Lección 2 - Ejecutar tu primera sesión de agent
 
 ### 3. Link check (lychee, offline)
 
-The site builds with `base=/agents-in-sdlc/`, so internal hrefs are absolute (`/agents-in-sdlc/foo/`). Symlink that prefix to `website/dist` so lychee can follow internal links:
+The site builds with `base=/copilot-workshops/`, so internal hrefs are absolute (`/copilot-workshops/foo/`). Symlink that prefix to `website/dist` so lychee can follow internal links:
 
 ```bash
-mkdir -p /tmp/lychee-root && ln -sfn "$PWD/website/dist" /tmp/lychee-root/agents-in-sdlc \
+mkdir -p /tmp/lychee-root && ln -sfn "$PWD/website/dist" /tmp/lychee-root/copilot-workshops \
   && lychee --offline --no-progress --root-dir /tmp/lychee-root 'website/dist/**/*.html'
 ```
 
@@ -110,6 +110,6 @@ When in doubt, `grep -rn "<old-name>" --include='*.md' .` (excluding `node_modul
 ```bash
 # from repo root
 cd website && rm -rf dist && npm run build && cd ..
-mkdir -p /tmp/lychee-root && ln -sfn "$PWD/website/dist" /tmp/lychee-root/agents-in-sdlc \
+mkdir -p /tmp/lychee-root && ln -sfn "$PWD/website/dist" /tmp/lychee-root/copilot-workshops \
   && lychee --offline --no-progress --root-dir /tmp/lychee-root 'website/dist/**/*.html'
 ```

--- a/.github/skills/publish-to-pages/README.md
+++ b/.github/skills/publish-to-pages/README.md
@@ -2,7 +2,7 @@
 
 `publish-to-pages` is a general-purpose skill for converting and publishing arbitrary content (PPTX, PDF, HTML, Google Slides) to a **new** GitHub Pages repo.
 
-**It is NOT the deployment workflow for this repo's site.** This repo's workshop site is built and deployed by [`.github/workflows/pages.yml`](../../workflows/pages.yml). That workflow runs automatically on pushes to `main` and publishes the Astro + Starlight build under `website/dist/` to <https://github-samples.github.io/agents-in-sdlc/>.
+**It is NOT the deployment workflow for this repo's site.** This repo's workshop site is built and deployed by [`.github/workflows/pages.yml`](../../workflows/pages.yml). That workflow runs automatically on pushes to `main` and publishes the Astro + Starlight build under `website/dist/` to <https://github-samples.github.io/copilot-workshops/>.
 
 Use `publish-to-pages` when you want to spin up a *separate* Pages site for, say, a slide deck or a one-off HTML artifact. Don't use it to deploy this repo.
 

--- a/.github/skills/validate-site-playwright/SKILL.md
+++ b/.github/skills/validate-site-playwright/SKILL.md
@@ -28,7 +28,7 @@ Serve the production build (not the dev server) so you validate exactly what shi
 cd website && npm run preview
 ```
 
-The site is served at <http://localhost:4321/agents-in-sdlc/>. Start it as a **detached background process** so it survives while you navigate, and capture its PID for teardown. Wait until the server logs that it's listening before navigating.
+The site is served at <http://localhost:4321/copilot-workshops/>. Start it as a **detached background process** so it survives while you navigate, and capture its PID for teardown. Wait until the server logs that it's listening before navigating.
 
 ## 2. Derive the routes to check
 
@@ -36,20 +36,20 @@ Don't hard-code URLs. The built `dist/` is the source of truth for what routes e
 
 ```bash
 # every built route, as site-absolute paths under the base
-find website/dist -name index.html | grep -v 404 | sed 's#website/dist#/agents-in-sdlc#; s#/index.html#/#'
+find website/dist -name index.html | grep -v 404 | sed 's#website/dist#/copilot-workshops#; s#/index.html#/#'
 ```
 
-Validate a **representative sample** that covers every layout and harness: the landing page (`/agents-in-sdlc/`), a per-harness prerequisites page (e.g. `cli/0-prerequisites/`), and at least one lesson from each of `cli/`, `vscode/`, `cloud/`, and `app/`. For a release pass or a change that touches shared layout/components, validate **all** routes.
+Validate a **representative sample** that covers every layout and harness: the landing page (`/copilot-workshops/`), a per-harness prerequisites page (e.g. `cli/0-prerequisites/`), and at least one lesson from each of `cli/`, `vscode/`, `cloud/`, and `app/`. For a release pass or a change that touches shared layout/components, validate **all** routes.
 
 ## 3. Validate each route
 
 For each chosen route, use the Playwright MCP tools:
 
-1. **Navigate** — `browser_navigate` to `http://localhost:4321/agents-in-sdlc/<route>`.
+1. **Navigate** — `browser_navigate` to `http://localhost:4321/copilot-workshops/<route>`.
 2. **Confirm it rendered** — `browser_snapshot` and check the page has its heading/title and real content (not an error page or raw, unrendered Markdown).
 3. **Check the console** — `browser_console_messages` with `level: "error"`. There should be **zero** errors. Hydration warnings and 404s for assets surface here.
 
-   *Known benign exception:* the legacy redirect route `/agents-in-sdlc/shared/0-prereqs/` is a minimal full-HTML redirect page (it immediately forwards to the home page `/agents-in-sdlc/` via a meta refresh) and declares no favicon, so the browser auto-requests `/favicon.ico` and logs a single `404 (Not Found)`. That one favicon 404 **on the redirect page only** is expected. Validate that route by confirming it lands on the home page, not by console cleanliness. A favicon 404 on any *real* page is a genuine finding (real pages link `favicon.svg`).
+   *Known benign exception:* the legacy redirect route `/copilot-workshops/shared/0-prereqs/` is a minimal full-HTML redirect page (it immediately forwards to the home page `/copilot-workshops/` via a meta refresh) and declares no favicon, so the browser auto-requests `/favicon.ico` and logs a single `404 (Not Found)`. That one favicon 404 **on the redirect page only** is expected. Validate that route by confirming it lands on the home page, not by console cleanliness. A favicon 404 on any *real* page is a genuine finding (real pages link `favicon.svg`).
 4. **Find broken images** — `browser_evaluate` with an async function that **force-loads lazy images first**, then flags only the ones that truly fail. Starlight/Astro mark below-the-fold images `loading="lazy"`, so a naive `naturalWidth === 0` check reports false positives for images that simply haven't scrolled into view yet:
 
    ```js

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,12 +44,12 @@ jobs:
       - name: Check links with lychee
         # Validates internal links/images in the produced HTML. Offline mode skips
         # external HTTP checks to keep CI deterministic and fast.
-        # The site is built with base=/agents-in-sdlc/, so HTML hrefs are absolute
-        # like /agents-in-sdlc/foo/. We construct a temp root where that prefix
+        # The site is built with base=/copilot-workshops/, so HTML hrefs are absolute
+        # like /copilot-workshops/foo/. We construct a temp root where that prefix
         # resolves to website/dist via a symlink so lychee can follow internal links.
         run: |
           mkdir -p /tmp/lychee-root
-          ln -sfn "$GITHUB_WORKSPACE/website/dist" /tmp/lychee-root/agents-in-sdlc
+          ln -sfn "$GITHUB_WORKSPACE/website/dist" /tmp/lychee-root/copilot-workshops
         shell: bash
 
       - name: Run lychee

--- a/AUTHORING.md
+++ b/AUTHORING.md
@@ -1,6 +1,6 @@
 # Authoring Guide
 
-This is the entry point for **content authors and maintainers** of **Copilot Workshops**. If you arrived here looking to *take* the workshop, head to the published site at <https://github-samples.github.io/agents-in-sdlc/>.
+This is the entry point for **content authors and maintainers** of **Copilot Workshops**. If you arrived here looking to *take* the workshop, head to the published site at <https://github-samples.github.io/copilot-workshops/>.
 
 ## Project overview model
 
@@ -9,7 +9,7 @@ This is the entry point for **content authors and maintainers** of **Copilot Wor
 - **Reusable prose is copied inline.** There is no import-based shared content system; keep duplicated lesson sections aligned with the content-alignment safety nets described below.
 
 ```
-agents-in-sdlc/
+copilot-workshops/
 ├── docs/                        ← Markdown source. EDIT HERE. Browsable on github.com.
 │   ├── README.md                ← Workshop landing page (also site home via slug: index)
 │   ├── cli/                     ← Copilot CLI lessons (0-prerequisites.md + numbered exercises)
@@ -108,7 +108,7 @@ npm install
 npm run dev
 ```
 
-The site runs at <http://localhost:4321/agents-in-sdlc/>.
+The site runs at <http://localhost:4321/copilot-workshops/>.
 
 **Verify** before committing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,10 +14,10 @@ If you want to **author or edit content**, start with [`AUTHORING.md`](./AUTHORI
 
 ## Submitting a pull request
 
-1. [Fork](https://github.com/github-samples/agents-in-sdlc/fork) and clone the repository.
+1. [Fork](https://github.com/github-samples/copilot-workshops/fork) and clone the repository.
 2. Create a topic branch (`git checkout -b my-change`).
 3. Make your change. Keep PRs focused — one logical change per PR.
-4. Push to your fork and [open a pull request](https://github.com/github-samples/agents-in-sdlc/compare).
+4. Push to your fork and [open a pull request](https://github.com/github-samples/copilot-workshops/compare).
 5. Wait for CI and review.
 
 ## Before merge

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 Workshop content for **Copilot Workshops**, a guided exploration of GitHub Copilot's agentic capabilities (Copilot CLI, VS Code agent mode, the Copilot app, and the Copilot cloud agent) across the software development lifecycle.
 
-The published site lives at **<https://github-samples.github.io/agents-in-sdlc/>**.
+The published site lives at **<https://github-samples.github.io/copilot-workshops/>**.
 
 > [!NOTE]
 > The demo application learners build through during the workshop — Tailspin Toys, a pure-Astro crowdfunding site (SSR, API endpoints, and a Drizzle data layer) — lives in a separate repository: **<https://github.com/github-samples/tailspin-toys>**. This repo holds only the *content*: lesson Markdown, images, and the Astro + Starlight site that publishes them.
 
 ## Start the workshop
 
-Visit the published site: <https://github-samples.github.io/agents-in-sdlc/>.
+Visit the published site: <https://github-samples.github.io/copilot-workshops/>.
 
 ## Authoring
 
@@ -45,7 +45,7 @@ npm install
 npm run dev
 ```
 
-The site runs at <http://localhost:4321/agents-in-sdlc/>.
+The site runs at <http://localhost:4321/copilot-workshops/>.
 
 ## Verification
 

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # Website (Astro + Starlight publisher)
 
-Optional publishing layer that renders the workshop content as a documentation site and deploys it to GitHub Pages at <https://github-samples.github.io/agents-in-sdlc/>.
+Optional publishing layer that renders the workshop content as a documentation site and deploys it to GitHub Pages at <https://github-samples.github.io/copilot-workshops/>.
 
 The lessons themselves are plain Markdown in the repo-root [`../docs/`](../docs/) directory — browsable directly on github.com with no build required. This `website/` project is only needed if you want to self-host or preview the rendered pages site. For author-focused guidance, see [`../AUTHORING.md`](../AUTHORING.md).
 
@@ -10,7 +10,7 @@ From this directory:
 
 ```sh
 npm install
-npm run dev      # http://localhost:4321/agents-in-sdlc/
+npm run dev      # http://localhost:4321/copilot-workshops/
 npm run build    # outputs to dist/
 npm run preview  # preview the production build
 ```

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -19,7 +19,7 @@ const githubAdmonitionMapping = {
 // https://astro.build/config
 export default defineConfig({
   site: 'https://github-samples.github.io',
-  base: '/agents-in-sdlc',
+  base: '/copilot-workshops',
   trailingSlash: 'always',
   markdown: {
     remarkPlugins: [
@@ -43,12 +43,12 @@ export default defineConfig({
         {
           icon: 'github',
           label: 'GitHub',
-          href: 'https://github.com/github-samples/agents-in-sdlc',
+          href: 'https://github.com/github-samples/copilot-workshops',
         },
       ],
       editLink: {
         baseUrl:
-          'https://github.com/github-samples/agents-in-sdlc/edit/main/docs/',
+          'https://github.com/github-samples/copilot-workshops/edit/main/docs/',
       },
       sidebar: [
         { label: 'Home', link: '/' },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "agents-in-sdlc-docs",
+  "name": "copilot-workshops-docs",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agents-in-sdlc-docs",
+      "name": "copilot-workshops-docs",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.9.4",

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agents-in-sdlc-docs",
+  "name": "copilot-workshops-docs",
   "type": "module",
   "version": "0.0.1",
   "private": true,


### PR DESCRIPTION
## Summary

Follow-up to #146 (squash-merged). The repository was renamed `agents-in-sdlc` → `copilot-workshops`, so the GitHub Pages project site now serves at `/copilot-workshops/`. This repoints every remaining `agents-in-sdlc` slug reference. Without it, the deployed site's base path is wrong and all assets/links 404.

## Type of change

- [ ] Workshop content (lesson Markdown, images)
- [x] Site shell (`website/` Astro + Starlight wrapper)
- [x] Copilot configuration (`.github/copilot-instructions.md`, instructions, agents, skills)
- [x] Repo housekeeping (CI, dependabot, README, license)
- [ ] Other:

### What changed (`agents-in-sdlc` → `copilot-workshops`)

- **Functional:** `website/astro.config.mjs` base path (`/copilot-workshops`) + site/edit/social URLs; `website/package.json` + `package-lock.json` name (`copilot-workshops-docs`); `.github/workflows/pages.yml` lychee symlink.
- **Docs/skills:** `README.md`, `AUTHORING.md`, `CONTRIBUTING.md`, `website/README.md`, `.github/copilot-instructions.md`, `.github/pull_request_template.md`, `.github/instructions/astro.instructions.md`, and 3 skill SKILL.md files (Pages URLs + `localhost:4321/…` paths).

## Verification

- [x] `cd website && rm -rf dist && npm run build` succeeds — 218 built HTML files (217 pages + 404); hrefs now emit `/copilot-workshops/…`.
- [x] Lychee offline link check passes — 0 errors (symlink retargeted to `/tmp/lychee-root/copilot-workshops`).
- [x] Confirmed no `agents-in-sdlc` references remain in tracked files.

## Notes for reviewers

- The published site will resolve at <https://github-samples.github.io/copilot-workshops/> once merged.
